### PR TITLE
Remove file size limit

### DIFF
--- a/Ranking/Criteria/de.md
+++ b/Ranking/Criteria/de.md
@@ -20,7 +20,6 @@ Folgendes trifft auf Metadaten zu, welche deine Map enthält, wie z.B. Song, Tit
 
 Folgendes trifft auf Medien zu, wie z.B. Hintergrundbilder und Audio-Dateien die in deinem Mapset enthalten sind.
 
-* • **Die Gesamtgröße des Mapsets (.qp) muss 15 Megabytes (MB) oder kleiner sein**
 * • **Die Auflösung des Hintergrundbildes muss mindestens 1280x720 sein** und hoher Qualität entsprechen.
 * • **Dein Mapset darf nur eine einzige Audio-Datei enthalten.** Mapsets mit mehreren Audio-Dateien ist es nicht möglich in den Ranked Status versetzt zu werden.
 

--- a/Ranking/Criteria/en.md
+++ b/Ranking/Criteria/en.md
@@ -20,7 +20,7 @@ The following pertains to metadata that your maps contain such as song artists, 
 
 The following pertains to media files such as background images and audio files that are contained in your mapset.
 
-* • **The total file size of the mapset (.qp) must be 15 megabytes (mb) or smaller.**
+* • **The total file size of the mapset (.qp) must be 50 megabytes (mb) or smaller.**
 * • **The resolution of background images must be at least 1280x720** and of exceptionally high quality.
 * • **Your mapset must contain only one audio file.** Multiple song file mapsets are not eligible to be ranked.
 * • **The maximum bitrate allowed for audio files is 192kbps.**

--- a/Ranking/Criteria/en.md
+++ b/Ranking/Criteria/en.md
@@ -20,7 +20,6 @@ The following pertains to metadata that your maps contain such as song artists, 
 
 The following pertains to media files such as background images and audio files that are contained in your mapset.
 
-* • **The total file size of the mapset (.qp) must be 50 megabytes (mb) or smaller.**
 * • **The resolution of background images must be at least 1280x720** and of exceptionally high quality.
 * • **Your mapset must contain only one audio file.** Multiple song file mapsets are not eligible to be ranked.
 * • **The maximum bitrate allowed for audio files is 192kbps.**


### PR DESCRIPTION
As discussed in the supervisors Discord channel
https://discordapp.com/channels/354206121386573824/526237541024661505/669316162336718848

The client prevents uploading beatmaps larger than 50mb (the new intended file size limit) so there's no point in keeping it in the Ranking Criteria if every map has to follow it anyway