### PR TITLE
Some clarifications and suggestions for both criterias

### DIFF
--- a/en-US/ranking/criteria.md
+++ b/en-US/ranking/criteria.md
@@ -28,6 +28,8 @@ The following pertains to metadata that your maps contain such as song artists, 
 The following pertains to media files such as background images and audio files that are contained in your mapset.
 
 * **The resolution of background images must be at least 1280x720** and of exceptionally high quality. The file size of a background image must not exceed 4 MB.
+* **The background image must be SFW.** Explicit content won't be tolerated.
+* **The background image must be coherent enough to compliment the song.**  
 * **The mapset must contain only one audio file.** Multiple song file mapsets are not eligible to be ranked.
 * **MP3 is the only allowed audio file format.**
 * **The maximum bitrate allowed for audio files is 192kbps.**
@@ -44,7 +46,8 @@ The following requirements are for the individual maps themselves.
 * **More than 75% of the length of the song must have notes to play.**
 * **At least one note must be placed in every column.**
 * **The maps must be at least 45 seconds long.**
-* **The maps must be timed as accurately as possible.** Timing points must not be used in place of scroll velocity changes.
+* **The maps must be timed as accurately as possible using the wavelength feature.** This is to standarize how Quaver manages offsets.
+* **Timing points must not be used in place of scroll velocity changes.**
 * **The maps must have a song select preview point that sufficently compliments the song.** It's usually placed before the chorus or at the beginning of a section. A solid preview point attracts more players to try the map.
 
 ### Difficulty Spread
@@ -74,10 +77,11 @@ The following descriptions are what each difficulty should typically look like. 
 * **Normal**
      * Maps at this level should typically start branching into patterns that don't undermap the song as heavily compared to easy and beginner.
      * 1/2 rhythms with more complicated note placements and jumps are suitable for this difficulty.
+     * 1/4 can be tolerated as long it's not too draining or demanding for the player and it doesn't create an abnormal difficulty spike.
 
 * **Hard**
      * At this level, your creativity as a mapper is able to shine as there are far less restrictions than the previous difficulties.
-     * Maps at this difficulty can branch into light 1/4th streams with jumps interspersed in them depending on the BPM of the song.
+     * Maps at this difficulty can branch into any pattern as long as the difficulty over the map doesn't spike significantly (depending on the BPM of the song).
      * Usage of more long notes are suited for this difficulty, as players will typically be learning to play them in more frequent circumstances.
 
 * **Insane**
@@ -109,10 +113,12 @@ Furthermore, **each game mode is treated separately.** If you are creating a map
 
 ## Guidelines
 
-The following are guidelines to consider when creating your mapset and submitting it for ranked status. **These are not mandatory and should be taken with a grain of salt.** Our intentions with this are to allow mappers to be creative with the types of maps they produce. As such, these guidelines are merely a way to increase your chances of getting your mapset ranked - although exceptions can be made.
+The following are guidelines to consider when creating your mapset and submitting it for ranked status. **This is some of the points that Modding Supervisors would check, judge and evaluate on a map.** Our intentions with this are to allow mappers to be creative with the types of maps they produce, at the same time of being able to release maps with high quality of mapping. As such, these guidelines are merely a way to increase your chances of getting your mapset ranked - **although exceptions can be made.**
 
 * **The intensity of the map should generally be synced with the music.** If a song is relatively mellow, the map should reflect this and vice versa.
 * **Your map should generally make use of layering.** - Mapping to different instruments in the song will make your map reflect the music more.
 * **Breaks should only be used when absolutely necessary** - A song will generally not have any silent moments throughout it. Breaks should be used sparingly - especially long ones.
 * **Scroll Velocity changes should reflect the music** - Try to avoid changing SV when the must doesn't call for it. This will generally make your map more difficult to read and harder to enjoy.
-* **The patterns you use should be consistent and follow the music** - Try to avoid using bursts where they aren't appropriate, such as before a dense stream section. Furthermore, try to avoid technical or intense patterns in places that do not call for them.
+* **The patterns you use should be consistent and represent in some way what's being played.** - Try to avoid using patterns where they aren't appropriate. Furthermore, try to avoid technical or intense patterns in places that do not call for them.
+* **Try to avoid copy-pasting sections of the map.** If the music is repetitive enough to use the exact same patterns, try to change their arrangement (for example, by mirroring them). This also applies when adding patterns with the intention of only filling some section.
+* **Every single section of the map has to be self-justified.** All patterns are allowed - as long as the map follows what is being played in the music.

--- a/en-US/ranking/process.md
+++ b/en-US/ranking/process.md
@@ -47,21 +47,17 @@ This section outlines the process of getting a mapset ranked from A-Z starting w
 
 The first step in getting a mapset ranked is uploading it. You can do this within the map editor by going to `File -> Upload`.
 
-### 2. Getting Feedback
+### 2. Submitting For Rank
 
-After uploading your set, it's important to receive feedback on your set before submitting it for rank. This is where the community comes in. While we do not currently have a system in place for getting structured feedback from other players, it is important to have an extra set of eyes take a look at your set to make sure it is following the Ranking Criteria. We'll be looking at making this step in the process more streamlined in the future.
+Players are eligible to submit their own mapsets for ranked status **when they feel it is ready.** You can submit a set for ranked status within the map editor by going to `File -> Submit for Rank`. This will send the mapset to a queue where our Ranking Supervisors will review it.
 
-### 3. Submitting For Rank
+### 3. Ranking and Modding Supervisors Reviewal
 
-Players are eligible to submit their own mapsets for ranked status when they feel it is ready. You can submit a set for ranked status within the map editor by going to `File -> Submit for Rank`. This will send the mapset to a queue where our Ranking Supervisors will review it.
+After submitting your set for rank, it will be placed in a queue for the Ranking and Modding Supervisor teams to review.
 
-### 4. Ranking Supervisor Reviewal
+In order to get your set ranked, **you will need to get 1 vote from each Supervisor team,** dictating if the set is eligible for rank.
 
-After submitting your set for rank, it will be placed in a queue for the Ranking Supervisor team to review.
-
-In order to get your set ranked, **you will need to get 2 votes from the Ranking Supervisors** that dictates if the set is eligible for rank.
-
-During this vote, **a Supervisor has the ability to veto a mapset from being ranked before it reaches 2 vote and are able place it in a denied state** if there are any issues with the set.
+During this vote, **either Supervisors or Modders have the ability to veto a mapset from being ranked before it reaches 2 votes and are able place it in a denied state** if there are any issues with the set.
 
 You can check the status of the vote for your set by going to its respective mapset page. Here will be displayed the amount of votes it has as well as the Supervisors who are nominating it for rank.
 
@@ -73,7 +69,7 @@ Supervisors are also not allowed to vote for their own mapsets. They must go thr
 
 ### 5a. Mapset Denied
 
-If your mapset is denied, you will receive a comment from one or more Ranking Supervisors with the reason(s) why. After this period, you are eligible to update your map with fixes to submit again for rank. **Keep in mind that if denied, your set will be placed in a cooldown period for 14 days until you are able to submit it again.**
+If your mapset is denied, you will receive a comment from one or more Ranking Supervisors with the reason(s) why. After this period, you are eligible to update your map with fixes to submit again for rank. **Keep in mind that if denied, your set will be placed in a cooldown period for 7 days until you are able to submit it again.**
 
 ### 5b. Mapset On-Hold
 
@@ -81,7 +77,7 @@ If your mapset is put on-hold, it means that minor issues were found that preven
 
 ### 5c. Mapset Resolved
 
-If the status of your mapset is on-hold, it has to be updated for it to automatically be marked as resolved. While in this state, the supervisors can review and vote for it again. 
+If the status of your mapset is on-hold, it has to be updated for it to automatically be marked as resolved. While in this state, the supervisors can review and vote for it again.
 
 ### 5d. Mapset Blacklisted
 


### PR DESCRIPTION
Okay, i'm gonna explain briefly the changes i proposed:


### Ranking Criteria

### About background images

There's several people that puts random images (or even NSFW ones) as background for ranked maps; of course you can choose freely what image do you like for the map, **because that is gonna be the map's "identity" (in some way) in the future.** And because of that fact, you shouldn't copy-paste backgrounds from other maps, or put random memes (or even the same memes) on every single map you make.

Have you ever differentiated a map because of the BG? Yeah, me too. It's crucial to select a nice background, and this should be regulated by Supervisors.

### About the Maps

The wavelength feature is almost a rule when you're checking if a map has the correct offset; some people may not use it since they don't know how it works, so i'm gonna explain it a little:

Before opening the map on the editor, turn on the option of "Pitch Audio With Playback Rate". If you don't do it, when you change the playback rate to 25% while checking the wavelength, you'll notice that neither the audio or the wavelength is on-sync. If it's enabled, you will be able to tell exactly where the sound starts, so you can map more precisely.

_Also, if you're a mapper/modder and you're using speakers, bluetooth headphones or anything like that, i gladly invite you to get something that doesn't apply so much latency, so people won't suffer explaining to you why some map starts -20ms earlier lol._

### About Difficulty Spread

I noticed that at normal and hard difficulties, there was no realistic case about nowaday's mapping; because you can make pretty complex maps without hitting insane levels on QR. With those 2 new points, there's a better approach on how maps are made right now (and how it should be actually, since at hard difficulties you should be able to at least have a glance of real patterns that appears on every difficult maps.

### About Guidelines

Okay, this is where everything will burn since some people would complain a LOT about it, so i'll explain it as detailed as possible.

The first paragraph was rewritten following the idea of my previous request (https://github.com/Quaver/Quaver/issues/3313), because this is exactly what MS would look at. In summary, this is not a mandatory rule, but every good map follows more than one of those points.

>_But what do you mean by "good map", are you saying it as a player, mapper or modder?_

I say it on a middle term between mapper and player (let's call it modder since it doesn't belong to any of the two, and also as a modder your job is to analyze a map in the most neutral way possible). 

### But what does Modders do exactly?

When you're checking a map, the very first thing you'll be looking at is what the mapper tried to represent: what instruments he followed, how he did it, what transitions he made to get into different sections of the music, was it good in terms of gameplay? was it good in terms of mapping? does it have consistency? is he missing a note? 
More than "watching if I like what he did" is more like "Was his idea well executed? Can he improve? And if so, how?".

As a modder you follow what the mapper did and check if it works, if he missed anything or if there's a better approach on the own mapper's ideas, _**you don't suggest what would you like to add. Before doing that you MUST suggest what he would like to add, to continue and improve his own idea.**_

Moving on to the last 3 points of the guidelines, the three of them were made to guarantee that the mapper isn't doing parkour on the editor, so Supervisors can judge the overall structure of the map.

> _B-but there's dumps and they don't follow the song that much..._

I saw this statement being made a lot of times on Quaver's Discord, so i'll explain this a bit:
Dumps are even harder to make than generic chordjack/jumpstream/handstream/stream maps, since mappers only take a piece of the music and map it whatever they like, then switch to another and so on. The magic about this, is the fact that gameplay keeps being smooth and comfortable enough to tell what instrument is being followed on the patterns. So yeah, dumps follow the music completely.



### Ranking Process

If you haven't seen my previous FR, please check it out, since most of this file was edited following the Modding Supervisors idea: https://github.com/Quaver/Quaver/issues/3313


### About deleting the feedback process

First of all, this step existed because _"we do not currently have a system in place for getting structured feedback from other players"_ and with the existence of MS, both the team and the community can have a proper structure of feedback during the ranking process.

>_But if you delete that, then everyone can send nonsense to be fixed afterwards by MS on the ranking queue_

Allow me to introduce the next step:

>2. Submitting For Rank
Players are eligible to submit their own mapsets for ranked status when they feel it is ready.

If the map it's not ready and it has a lot of work to be made before ranking, it will be yeeted out from the queue, pretty simple, right?

### About "Ranking and Modding Supervisors Reviewal"

Nothing new and nothing special if you already read the previous request, i only rewrote this point adding the 1MS + 1RS vote system for ranking and the existence of the team, working along with Ranking Supervisors. (remember that in this system, the main role of MS would be checking the map itself, and RS would check all the metadata).

### About the 14 -> 7 days of cooldown on Deny status

I think this is completely abusive. people who do care about a map, even if they have to fix most of it, it won't take even a week to do it (implying they're not busy); the issue here is that this 14 day cooldown has the purpose to wipe the ranking queue faster, and this merges with the very first problem mentioned in the previous request: the RS activity.

And also there's another factor that is part of the problem, and it's the slots that mappers get when they already ranked more than one map. This is a privilege that can be handled ONLY if the activity of the supervisors is already high (so the queue doesn't die), but this is not the case, so the slots should be reduced, or even deleted (unless there's more activity and more people join to help).

So basically, reducing the cooldown gives hope to new mappers to not be purged by half a month, re-submit their map with everything fixed asap and get it ranked (since with MS the flow will be faster because there's gonna be people checking the actual maps).

### Additional info

Well, this took a while to plannify and i know this is gonna be pretty controversial since not everyone would like it (by adding rules to mapping, some mappers may feel limited to what they want to do, but in reality it's just advices to make something enjoyable (from the players perspective) and justified (from the mapper's perspective). Feel free to comment if there's something that you didn't understand, something that i didn't explained or something i missed.

**Special thanks to @AiAe for explaining me how to use Git in general and how to make a pull request (if it wasn't for him, i would have suffered multiple aneurysms trying to make this thing work), and also Skalim, for helping me to create this whole document while discussing what was the most critical issues with both Ranking Criteria and Process.** 