### PR TITLE
New Tab in Wiki: Tournament.

### DIFF
--- a/TOC.ini
+++ b/TOC.ini
@@ -5,6 +5,7 @@
 -: editor
 -: ranking
 -: multiplayer
+-: tournament
 -: api
 -: rules
 -: legal
@@ -32,6 +33,11 @@
 [multiplayer]
 -: README
 -: commands
+
+[tournament]
+-: README
+-: skinelements
+-: settings.ini
 
 [rules]
 -: README

--- a/en-US/tournament/README.md
+++ b/en-US/tournament/README.md
@@ -37,6 +37,7 @@ IMPORTANT NOTES:
 - Under the `[BestOf]` setting, you must set `BestOfCustomText` to the current best of count such as **B07**, **BO11**, etc.
 - You must update these values each round of the tournament.
 - Keep track of all your original settings so you can switch back to them after streaming.
+- Keep in mind that adjusting any values in `settings.ini` will update the tournament overlay in real time.
 
 ## Setting up the tournament for streaming/recording
 

--- a/en-US/tournament/README.md
+++ b/en-US/tournament/README.md
@@ -27,20 +27,20 @@ Quaver provides customizable tournament settings and skin elements for the playe
 
 After setting up the miscellaneous assets for tournament, you may now start configuring the tournament settings by adjusting values in `settings.ini` file. In order to know how the values work in the file, please go to [Settings.ini](/docs/Tournament/settings.ini) tab.
 
-Other skinnable elements may also be found in the [Skin Elements](/docs/Tournament/skinelements) tab.
+Other skinnable elements may be found in the [Skin Elements](/docs/Tournament/skinelements) tab.
 
 IMPORTANT NOTES:
 
 - Make sure to go into Settings and turn `Display 1v1 Playfield Scores` off and turn `Display 1v1 Tournament Overlay` on.
-- In `Settings.ini`, under the [MatchRound] setting, you must set `MatchRoundCustomText` to the current round of the tournament.
+- In `Settings.ini`, under the `[MatchRound]` setting, you must set `MatchRoundCustomText` to the current round of the tournament.
   - For example, if the round of the tournament is **Semi-Finals**, you must set the value to `Semi-Finals`.
-- Under the [BestOf] setting, you must set `BestOfCustomText` to the current best of count such as **B07**, **BO11**, etc.
+- Under the `[BestOf]` setting, you must set `BestOfCustomText` to the current best of count such as **B07**, **BO11**, etc.
 - You must update these values each round of the tournament.
 - Keep track of all your original settings so you can switch back to them after streaming.
 
 ## Setting up the tournament for streaming/recording
 
-As for the tournament timer in stream, [Snaz](https://github.com/JimmyAppelt/Snaz/wiki) is recommended to use for countdowns. You may check the wiki to install the program.
+As for the tournament timer in stream, [Snaz](https://github.com/JimmyAppelt/Snaz/wiki) is recommended to use for countdowns. You may check their wiki to install the program.
 
 [OBS](https://obsproject.com) is a recommended program used for streaming or recording tournament in Quaver and **Snaz** has a tutorial on how to set up the program for **OBS**.
 

--- a/en-US/tournament/README.md
+++ b/en-US/tournament/README.md
@@ -1,0 +1,54 @@
+---
+name: Tournament
+---
+
+# Tournament
+
+Quaver provides customizable tournament settings and skin elements for the players who want to host a tournament.
+
+- [Skin Elements](/docs/Tournament/skinelements)
+- [Settings.ini](/docs/Tournament/settings.ini)
+
+## How do I start setting up my tournament?
+
+• First, you must have a `Tournament` folder in Quaver directory. This is where you will place the required files to start setting up the tournament settings in multiplayer.
+
+• Second, make sure that you place these files in `Tournament` folder:
+
+- `settings.ini`
+- `tournament-overlay.png`
+- `winner-1.png`
+- `winner-2.png`
+
+• Third, make sure that you have selected the custom tournament skin in the Skin settings for both `Custom Skin` and `Co-op Player 2 Skin`.
+
+- It is advised that the skins loaded for the tournament use a different color per player.
+- In default settings, the `Custom Skin`/`Player 1 Skin` uses red color while `Co-op Player 2 Skin` uses blue color.
+
+After setting up the miscellaneous assets for tournament, you may now start configuring the tournament settings by adjusting values in `settings.ini` file. In order to know how the values work in the file, please go to [Settings.ini](/docs/Tournament/settings.ini) tab.
+
+Other skinnable elements may also be found in the [Skin Elements](/docs/Tournament/skinelements) tab.
+
+IMPORTANT NOTES:
+
+- Make sure to go into Settings and turn `Display 1v1 Playfield Scores` off and turn `Display 1v1 Tournament Overlay` on.
+- In `Settings.ini`, under the [MatchRound] setting, you must set `MatchRoundCustomText` to the current round of the tournament.
+  - For example, if the round of the tournament is **Semi-Finals**, you must set the value to `Semi-Finals`.
+- Under the [BestOf] setting, you must set `BestOfCustomText` to the current best of count such as **B07**, **BO11**, etc.
+- You must update these values each round of the tournament.
+- Keep track of all your original settings so you can switch back to them after streaming.
+
+## Setting up the tournament for streaming/recording
+
+As for the tournament timer in stream, [Snaz](https://github.com/JimmyAppelt/Snaz/wiki) is recommended to use for countdowns. You may check the wiki to install the program.
+
+[OBS](https://obsproject.com) is a recommended program used for streaming or recording tournament in Quaver and **Snaz** has a tutorial on how to set up the program for **OBS**.
+
+• To set up the timer, open **Snaz** and go to `Countdown to specific time`. Set the output format to `$m:$s` and `Msg when done` to **00:00**.
+
+• Click `Copy Path to Clipboard`. In OBS, create a **Time Counter** source where you can set up the timer in the Scene. To set the counter, open the source, click `Browse`, and paste the path next to the "File name". Then, click `Open`.
+
+NOTES:
+
+- **Snaz** counts down to a specific time. You should set this time before starting the stream. Usually it will be the current day on the next hour.
+- **For Example**: If the match is at `10:00 UTC 02/26/2022`, you should set the **Snaz** to that time so it'll start counting down to it.

--- a/en-US/tournament/settings.ini.md
+++ b/en-US/tournament/settings.ini.md
@@ -1,0 +1,250 @@
+---
+name: Settings.ini
+---
+
+# Configuring settings.ini
+
+Tournament overlay setting in Quaver comes with a lot of customizations where you can set most of the values to blend in with the custom tournament overlay for streaming or recording a tournament match.
+
+# Players Settings
+
+The `[Players]` section contains customization for the players' username in the lobby.
+
+## Player 1
+
+|               Value               |       Data Type        | Default Values |
+| :-------------------------------: | :--------------------: | :------------: |
+|      Player1UsernameVisible       | Boolean(True or False) |      True      |
+|      Player1UsernameFontSize      |        Integer         |       36       |
+|      Player1UsernamePosition      |     Integer(X, Y)      |     240,43     |
+|     Player1UsernameAlignment      |       Alignment        |     Center     |
+|       Player1UsernameColor        | RGB Color(255,255,255) |   249,100,93   |
+|      Player1UsernameInverted      | Boolean(True or False) |     False      |
+|        Player1UsernameFont        |         String         |   Lato-Bold    |
+|  Player1UsernameColorWhenLosing   | RGB Color(255,255,255) |   249,100,93   |
+| Player1UsernameFontSizeWhenLosing |        Integer         |       26       |
+|          Player1MaxWidth          |        Integer         |   2147483647   |
+
+## Player 2
+
+|               Value               |       Data Type        | Default Values |
+| :-------------------------------: | :--------------------: | :------------: |
+|      Player2UsernameVisible       | Boolean(True or False) |      True      |
+|      Player2UsernameFontSize      |        Integer         |       36       |
+|      Player2UsernamePosition      |     Integer(X, Y)      |    1370,43     |
+|     Player2UsernameAlignment      |       Alignment        |     Center     |
+|       Player2UsernameColor        | RGB Color(255,255,255) |   5,135,229    |
+|      Player2UsernameInverted      | Boolean(True or False) |     False      |
+|        Player2UsernameFont        |         String         |   Lato-Bold    |
+|  Player2UsernameColorWhenLosing   | RGB Color(255,255,255) |   5,135,229    |
+| Player2UsernameFontSizeWhenLosing |        Integer         |       26       |
+|          Player2MaxWidth          |        Integer         |   2147483647   |
+
+---
+
+The `[Wins]` section contains customization for the players' win count in the lobby.
+
+## Player 1
+
+|               Value               |       Data Type        | Default Values |
+| :-------------------------------: | :--------------------: | :------------: |
+|      Player1WinCountVisible       | Boolean(True or False) |      True      |
+|      Player1WinCountFontSize      |        Integer         |       46       |
+|      Player1WinCountPosition      |     Integer(X, Y)      |   -893,-480    |
+|     Player1WinCountAlignment      |       Alignment        |   MidCenter    |
+|       Player1WinCountColor        | RGB Color(255,255,255) |   242,201,76   |
+|      Player1WinCountInverted      | Boolean(True or False) |      True      |
+|        Player1WinCountFont        |         String         |   Lato-Bold    |
+|  Player1WinCountColorWhenLosing   | RGB Color(255,255,255) |  255,255,255   |
+| Player1WinCountFontSizeWhenLosing |        Integer         |       30       |
+|      Player1WinCountMaxWidth      |        Integer         |   2147483647   |
+
+## Player 2
+
+|               Value               |       Data Type        | Default Values |
+| :-------------------------------: | :--------------------: | :------------: |
+|      Player2WinCountVisible       | Boolean(True or False) |      True      |
+|      Player2WinCountFontSize      |        Integer         |       46       |
+|      Player2WinCountPosition      |     Integer(X, Y)      |    893,-480    |
+|     Player2WinCountAlignment      |       Alignment        |   MidCenter    |
+|       Player2WinCountColor        | RGB Color(255,255,255) |   242,201,76   |
+|      Player2WinCountInverted      | Boolean(True or False) |      True      |
+|        Player2WinCountFont        |         String         |   Lato-Bold    |
+|  Player2WinCountColorWhenLosing   | RGB Color(255,255,255) |  255,255,255   |
+| Player2WinCountFontSizeWhenLosing |        Integer         |       30       |
+|      Player2WinCountMaxWidth      |        Integer         |   2147483647   |
+
+---
+
+The `[Accuracy]` section contains customization for the players' accuracy in the lobby.
+
+## Player 1
+
+|               Value               |       Data Type        | Default Values |
+| :-------------------------------: | :--------------------: | :------------: |
+|      Player1AccuracyVisible       | Boolean(True or False) |      True      |
+|      Player1AccuracyFontSize      |        Integer         |       46       |
+|      Player1AccuracyPosition      |     Integer(X, Y)      |    -615,510    |
+|     Player1AccuracyAlignment      |       Alignment        |   MidCenter    |
+|       Player1AccuracyColor        | RGB Color(255,255,255) |  214,215,215   |
+|      Player1AccuracyInverted      | Boolean(True or False) |      True      |
+|        Player1AccuracyFont        |         String         |   Lato-Bold    |
+|  Player1AccuracyColorWhenLosing   | RGB Color(255,255,255) |  214,215,215   |
+| Player1AccuracyFontSizeWhenLosing |        Integer         |       30       |
+|      Player1AccuracyMaxWidth      |        Integer         |   2147483647   |
+
+## Player 2
+
+|               Value               |       Data Type        | Default Values |
+| :-------------------------------: | :--------------------: | :------------: |
+|      Player2AccuracyVisible       | Boolean(True or False) |      True      |
+|      Player2AccuracyFontSize      |        Integer         |       46       |
+|      Player2AccuracyPosition      |     Integer(X, Y)      |    615,510     |
+|     Player2AccuracyAlignment      |       Alignment        |   MidCenter    |
+|       Player2AccuracyColor        | RGB Color(255,255,255) |  214,215,215   |
+|      Player2AccuracyInverted      | Boolean(True or False) |      True      |
+|        Player2AccuracyFont        |         String         |   Lato-Bold    |
+|  Player2AccuracyColorWhenLosing   | RGB Color(255,255,255) |  214,215,215   |
+| Player2AccuracyFontSizeWhenLosing |        Integer         |       30       |
+|      Player2AccuracyMaxWidth      |        Integer         |   2147483647   |
+
+---
+
+The `[Rating]` section contains customization for the players' rating in the lobby.
+
+## Player 1
+
+|              Value              |       Data Type        | Default Values |
+| :-----------------------------: | :--------------------: | :------------: |
+|      Player1RatingVisible       | Boolean(True or False) |      True      |
+|      Player1RatingFontSize      |        Integer         |       60       |
+|      Player1RatingPosition      |     Integer(X, Y)      |    -615,460    |
+|     Player1RatingAlignment      |       Alignment        |   MidCenter    |
+|       Player1RatingColor        | RGB Color(255,255,255) |   242,201,76   |
+|      Player1RatingInverted      | Boolean(True or False) |      True      |
+|        Player1RatingFont        |         String         |   Lato-Bold    |
+|  Player1RatingColorWhenLosing   | RGB Color(255,255,255) |  255,255,255   |
+| Player1RatingFontSizeWhenLosing |        Integer         |       50       |
+|         Player1MaxWidth         |        Integer         |   2147483647   |
+
+## Player 2
+
+|              Value              |       Data Type        | Default Values |
+| :-----------------------------: | :--------------------: | :------------: |
+|      Player2RatingVisible       | Boolean(True or False) |      True      |
+|      Player2RatingFontSize      |        Integer         |       60       |
+|      Player2RatingPosition      |     Integer(X, Y)      |    615,460     |
+|     Player2RatingAlignment      |       Alignment        |   MidCenter    |
+|       Player2RatingColor        | RGB Color(255,255,255) |   242,201,76   |
+|      Player2RatingInverted      | Boolean(True or False) |      True      |
+|        Player2RatingFont        |         String         |   Lato-Bold    |
+|  Player2RatingColorWhenLosing   | RGB Color(255,255,255) |  255,255,255   |
+| Player2RatingFontSizeWhenLosing |        Integer         |       50       |
+|         Player2MaxWidth         |        Integer         |   2147483647   |
+
+---
+
+The `[Modifiers]` section contains customization for the players' modifiers in the lobby.
+
+## Player 1
+
+|           Value           |       Data Type        | Default Values |
+| :-----------------------: | :--------------------: | :------------: |
+|  Player1ModifiersVisible  | Boolean(True or False) |      True      |
+|  Player1ModifiersLayout   |         String         |   Horizontal   |
+| Player1ModifiersPosition  |     Integer(X, Y)      |   -893,-480    |
+| Player1ModifiersAlignment |       Alignment        |   MidCenter    |
+|   Player1ModifiersScale   | RGB Color(255,255,255) |   242,201,76   |
+|  Player1ModifiersSpacing  | Boolean(True or False) |      True      |
+
+## Player 2
+
+|           Value           |       Data Type        | Default Values |
+| :-----------------------: | :--------------------: | :------------: |
+|  Player2ModifiersVisible  | Boolean(True or False) |      True      |
+|  Player2ModifiersLayout   |         String         |   Horizontal   |
+| Player2ModifiersPosition  |     Integer(X, Y)      |   -175,-480    |
+| Player2ModifiersAlignment |       Alignment        |    MidRight    |
+|   Player2ModifiersScale   |        Integer         |       70       |
+|  Player2ModifiersSpacing  |        Integer         |      -40       |
+
+---
+
+The `[WinnerDisplays]` section contains customization for the winner elements in the lobby.
+
+## Player 1
+
+|                 Value                  |       Data Type        | Default Values |
+| :------------------------------------: | :--------------------: | :------------: |
+|      Player1WinnerDisplayVisible       | Boolean(True or False) |      True      |
+|      Player1WinnerDisplayPosition      |     Integer(X, Y)      |       46       |
+|     Player1WinnerDisplayAlignment      |       Alignment        |   BottomLeft   |
+|       Player1WinnerDisplayScale        |        Integer         |      100       |
+| Player1WinnerDisplayFontSizeWhenLosing |        Integer         |       26       |
+
+## Player 2
+
+|                 Value                  |       Data Type        | Default Values |
+| :------------------------------------: | :--------------------: | :------------: |
+|      Player2WinnerDisplayVisible       | Boolean(True or False) |      True      |
+|      Player2WinnerDisplayPosition      |        Integer         |       46       |
+|     Player2WinnerDisplayAlignment      |       Alignment        |  BottomRight   |
+|       Player2WinnerDisplayScale        |        Integer         |      100       |
+| Player1WinnerDisplayFontSizeWhenLosing |        Integer         |       26       |
+
+---
+
+# Mapset Settings
+
+Mapset Settings contains of the song's title, difficulty name, length, BPM, rating, and the map creator.
+
+The `[Song]` section contains customization of the song title in the overlay.
+
+|            Value             |       Data Type        | Default Values |
+| :--------------------------: | :--------------------: | :------------: |
+|       SongTitleVisible       | Boolean(True or False) |      True      |
+|      SongTitleFontSize       |        Integer         |       22       |
+|      SongTitlePosition       |     Integer(X, Y)      |     0,-225     |
+|      SongTitleAlignment      |       Alignment        |   BotCenter    |
+|        SongTitleColor        | RGB Color(255,255,255) |  255,255,255   |
+|      SongTitleInverted       | Boolean(True or False) |      True      |
+|        SongTitleFont         |         String         |   Lato-Bold    |
+| Player1RatingColorWhenLosing | RGB Color(255,255,255) |  255,255,255   |
+|    SongTitleDimWhenLosing    | Boolean(True or False) |     False      |
+|      SongTitleMaxWidth       |        Integer         |      450       |
+
+---
+
+The `[DifficultyName]` section contains customization of the difficulty name in the overlay.
+
+|             Value             |       Data Type        | Default Values |
+| :---------------------------: | :--------------------: | :------------: |
+|     DifficultyNameVisible     | Boolean(True or False) |      True      |
+|    DifficultyNameFontSize     |        Integer         |       22       |
+|    DifficultyNamePosition     |     Integer(X, Y)      |     0,-177     |
+|    DifficultyNameAlignment    |       Alignment        |   BotCenter    |
+|      DifficultyNameColor      | RGB Color(255,255,255) |  255,255,255   |
+|    DifficultyNameInverted     | Boolean(True or False) |      True      |
+|      DifficultyNameFont       |         String         |   Lato-Bold    |
+| DifficultyNameColorWhenLosing | RGB Color(255,255,255) |  150,150,150   |
+| DifficultyNameUseDefaultColor | Boolean(True or False) |      True      |
+|    DifficultyNameMaxWidth     |        Integer         |      400       |
+
+---
+
+The `[SongLength]` section contains customization of the difficulty name in the overlay.
+
+|             Value             |       Data Type        | Default Values |
+| :---------------------------: | :--------------------: | :------------: |
+|     DifficultyNameVisible     | Boolean(True or False) |      True      |
+|    DifficultyNameFontSize     |        Integer         |       22       |
+|    DifficultyNamePosition     |     Integer(X, Y)      |     0,-177     |
+|    DifficultyNameAlignment    |       Alignment        |   BotCenter    |
+|      DifficultyNameColor      | RGB Color(255,255,255) |  255,255,255   |
+|    DifficultyNameInverted     | Boolean(True or False) |      True      |
+|      DifficultyNameFont       |         String         |   Lato-Bold    |
+| DifficultyNameColorWhenLosing | RGB Color(255,255,255) |  150,150,150   |
+| DifficultyNameUseDefaultColor | Boolean(True or False) |      True      |
+|    DifficultyNameMaxWidth     |        Integer         |      400       |
+
+---

--- a/en-US/tournament/settings.ini.md
+++ b/en-US/tournament/settings.ini.md
@@ -200,18 +200,18 @@ Mapset Settings contains of the song's title, difficulty name, length, BPM, rati
 
 The `[Song]` section contains customization of the song title in the overlay.
 
-|            Value             |       Data Type        | Default Values |
-| :--------------------------: | :--------------------: | :------------: |
-|       SongTitleVisible       | Boolean(True or False) |      True      |
-|      SongTitleFontSize       |        Integer         |       22       |
-|      SongTitlePosition       |     Integer(X, Y)      |     0,-225     |
-|      SongTitleAlignment      |       Alignment        |   BotCenter    |
-|        SongTitleColor        | RGB Color(255,255,255) |  255,255,255   |
-|      SongTitleInverted       | Boolean(True or False) |      True      |
-|        SongTitleFont         |         String         |   Lato-Bold    |
-| Player1RatingColorWhenLosing | RGB Color(255,255,255) |  255,255,255   |
-|    SongTitleDimWhenLosing    | Boolean(True or False) |     False      |
-|      SongTitleMaxWidth       |        Integer         |      450       |
+|          Value           |       Data Type        | Default Values |
+| :----------------------: | :--------------------: | :------------: |
+|     SongTitleVisible     | Boolean(True or False) |      True      |
+|    SongTitleFontSize     |        Integer         |       22       |
+|    SongTitlePosition     |     Integer(X, Y)      |     0,-225     |
+|    SongTitleAlignment    |       Alignment        |   BotCenter    |
+|      SongTitleColor      | RGB Color(255,255,255) |  255,255,255   |
+|    SongTitleInverted     | Boolean(True or False) |      True      |
+|      SongTitleFont       |         String         |   Lato-Bold    |
+| SongTitleColorWhenLosing | RGB Color(255,255,255) |  255,255,255   |
+|  SongTitleDimWhenLosing  | Boolean(True or False) |     False      |
+|    SongTitleMaxWidth     |        Integer         |      450       |
 
 ---
 
@@ -232,19 +232,114 @@ The `[DifficultyName]` section contains customization of the difficulty name in 
 
 ---
 
-The `[SongLength]` section contains customization of the difficulty name in the overlay.
+The `[SongLength]` section contains customization of the song's length in the overlay.
 
-|             Value             |       Data Type        | Default Values |
-| :---------------------------: | :--------------------: | :------------: |
-|     DifficultyNameVisible     | Boolean(True or False) |      True      |
-|    DifficultyNameFontSize     |        Integer         |       22       |
-|    DifficultyNamePosition     |     Integer(X, Y)      |     0,-177     |
-|    DifficultyNameAlignment    |       Alignment        |   BotCenter    |
-|      DifficultyNameColor      | RGB Color(255,255,255) |  255,255,255   |
-|    DifficultyNameInverted     | Boolean(True or False) |      True      |
-|      DifficultyNameFont       |         String         |   Lato-Bold    |
-| DifficultyNameColorWhenLosing | RGB Color(255,255,255) |  150,150,150   |
-| DifficultyNameUseDefaultColor | Boolean(True or False) |      True      |
-|    DifficultyNameMaxWidth     |        Integer         |      400       |
+|           Value           |       Data Type        | Default Values |
+| :-----------------------: | :--------------------: | :------------: |
+|     SongLengthVisible     | Boolean(True or False) |     False      |
+|    SongLengthFontSize     |        Integer         |       26       |
+|    SongLengthPosition     |     Integer(X, Y)      |    -50,-100    |
+|    SongLengthAlignment    |       Alignment        |   BotCenter    |
+|      SongLengthColor      | RGB Color(255,255,255) |  255,255,255   |
+|    SongLengthInverted     | Boolean(True or False) |      True      |
+|      SongLengthFont       |         String         |   Lato-Bold    |
+| SongLengthColorWhenLosing | RGB Color(255,255,255) |  255,255,255   |
+|    SongLengthMaxWidth     |        Integer         |   2147483647   |
 
 ---
+
+The `[SongBpm]` section contains customization of the song's BPM in the overlay.
+
+|         Value          |       Data Type        | Default Values |
+| :--------------------: | :--------------------: | :------------: |
+|     SongBpmVisible     | Boolean(True or False) |      True      |
+|    SongBpmFontSize     |        Integer         |       26       |
+|    SongBpmPosition     |     Integer(X, Y)      |    50,-100     |
+|    SongBpmAlignment    |       Alignment        |   BotCenter    |
+|      SongBpmColor      | RGB Color(255,255,255) |  255,255,255   |
+|    SongBpmInverted     | Boolean(True or False) |      True      |
+|      SongBpmFont       |         String         |   Lato-Bold    |
+| SongBpmColorWhenLosing | RGB Color(255,255,255) |  150,150,150   |
+|    SongBpmMaxWidth     |        Integer         |   2147483647   |
+
+---
+
+The `[DifficultyRating]` section contains customization of the difficulty rating of the map in the overlay.
+
+|              Value              |       Data Type        | Default Values |
+| :-----------------------------: | :--------------------: | :------------: |
+|     DifficultyRatingVisible     | Boolean(True or False) |      True      |
+|    DifficultyRatingFontSize     |        Integer         |       24       |
+|    DifficultyRatingPosition     |     Integer(X, Y)      |     0,-198     |
+|    DifficultyRatingAlignment    |       Alignment        |   BotCenter    |
+|      DifficultyRatingColor      | RGB Color(255,255,255) |  255,255,255   |
+|    DifficultyRatingInverted     | Boolean(True or False) |      True      |
+|      DifficultyRatingFont       |         String         |   Lato-Bold    |
+| DifficultyRatingColorWhenLosing | RGB Color(255,255,255) |  150,150,150   |
+| DifficultyRatingUseDefaultColor | Boolean(True or False) |      True      |
+|    DifficultyRatingMaxWidth     |        Integer         |   2147483647   |
+
+---
+
+The `[MapCreator]` section contains customization of the map creator's name in the overlay.
+
+|          Value           |       Data Type        | Default Values |
+| :----------------------: | :--------------------: | :------------: |
+|     SongTitleVisible     | Boolean(True or False) |      True      |
+|    SongTitleFontSize     |        Integer         |       22       |
+|    SongTitlePosition     |     Integer(X, Y)      |     0,-225     |
+|    SongTitleAlignment    |       Alignment        |   BotCenter    |
+|      SongTitleColor      | RGB Color(255,255,255) |  255,255,255   |
+|    SongTitleInverted     | Boolean(True or False) |      True      |
+|      SongTitleFont       |         String         |   Lato-Bold    |
+| SongTitleColorWhenLosing | RGB Color(255,255,255) |  255,255,255   |
+|  SongTitleDimWhenLosing  | Boolean(True or False) |     False      |
+|    SongTitleMaxWidth     |        Integer         |      450       |
+
+---
+
+The `[MatchRound]` section contains customization of the round of the match text in the overlay.
+
+|           Value           |       Data Type        | Default Values |
+| :-----------------------: | :--------------------: | :------------: |
+|   MatchRoundCustomText    |         String         |  Round of 64   |
+|     MatchRoundVisible     | Boolean(True or False) |      True      |
+|    MatchRoundFontSize     |        Integer         |       46       |
+|    MatchRoundPosition     |     Integer(X, Y)      |     0,-424     |
+|    MatchRoundAlignment    |       Alignment        |   MidCenter    |
+|      MatchRoundColor      | RGB Color(255,255,255) |   69,214,245   |
+|    MatchRoundInverted     | Boolean(True or False) |      True      |
+|      MatchRoundFont       |         String         |   Lato-Bold    |
+| MatchRoundColorWhenLosing | RGB Color(255,255,255) |   69,214,245   |
+|    MatchRoundMaxWidth     |        Integer         |      550       |
+
+---
+
+The `[BestOf]` section contains customization of the best of text in the overlay.
+
+|         Value         |       Data Type        | Default Values |
+| :-------------------: | :--------------------: | :------------: |
+|   BestOfCustomText    |         String         |   Best of 7    |
+|     BestOfVisible     | Boolean(True or False) |      True      |
+|    BestOfFontSize     |        Integer         |       26       |
+|    BestOfPosition     |     Integer(X, Y)      |     0,-363     |
+|    BestOfAlignment    |       Alignment        |   MidCenter    |
+|      BestOfColor      | RGB Color(255,255,255) |   69,214,245   |
+|    BestOfInverted     | Boolean(True or False) |      True      |
+|      BestOfFont       |         String         |   Lato-Bold    |
+| BestOfColorWhenLosing | RGB Color(255,255,255) |   69,214,245   |
+|    BestOfMaxWidth     |        Integer         |      300       |
+
+---
+
+The `[Banner]` section contains customization of the banner of the map's background in the overlay.
+
+|          Value          |       Data Type        | Default Values |
+| :---------------------: | :--------------------: | :------------: |
+|      BannerVisible      | Boolean(True or False) |      True      |
+|       BannerSize        | Integer(Width, Height) |    382,115     |
+|     BannerPosition      |     Integer(X, Y)      |     1,226      |
+|     BannerAlignment     |       Alignment        |   MidCenter    |
+|  BannerBackgroundSize   | Integer(Width, Height) |    498,280     |
+|   BannerDarknessAlpha   |     Float(0.0~1.0)     |      0.0       |
+| BannerBackgroundOffsetY |        Integer         |       0        |

--- a/en-US/tournament/skinelements.md
+++ b/en-US/tournament/skinelements.md
@@ -1,0 +1,40 @@
+---
+name: Skin Elements
+---
+
+# Skinning the Tournament Elements
+
+The tournament interface consists of 3 customizable elements. This only shows up when you are spectating a multiplayer lobby that consists of 2 players and have the setting `Display 1v1 Tournament Overlay` turned on.
+
+## Tournament Overlay
+
+`/Tournament/tournament-overlay.png`
+
+| Animatable | Alignment | Suggested Size |
+| :--------: | :-------: | :------------: |
+|     No     |  Center   |   1920x1080    |
+
+Notes:
+
+- The tournament overlay and stream overlay is created only for Full HD resolution (1920x1080). Using another resolutions may be problematic.
+
+## Winner Elements
+
+### For Player 1
+
+`/Tournament/winner-1.png`
+
+| Animatable | Alignment  | Suggested Size |
+| :--------: | :--------: | :------------: |
+|     No     | BottomLeft |    678x116     |
+
+### For Player 2
+
+`/Tournament/winner-2.png`
+
+| Animatable |  Alignment  | Suggested Size |
+| :--------: | :---------: | :------------: |
+|     No     | BottomRight |    678x116     |
+
+Notes:
+- This element will only display in their respective alignments depending on which player has the higher rating in the match.

--- a/en-US/tournament/skinelements.md
+++ b/en-US/tournament/skinelements.md
@@ -37,4 +37,5 @@ Notes:
 |     No     | BottomRight |    678x116     |
 
 Notes:
+
 - This element will only display in their respective alignments depending on which player has the higher rating in the match.

--- a/en-US/tournament/skinelements.md
+++ b/en-US/tournament/skinelements.md
@@ -12,11 +12,12 @@ The tournament interface consists of 3 customizable elements. This only shows up
 
 | Animatable | Alignment | Suggested Size |
 | :--------: | :-------: | :------------: |
-|     No     |  Center   |   1920x1080    |
+|     No     |  Center   |      None      |
 
 Notes:
 
-- The tournament overlay and stream overlay is created only for Full HD resolution (1920x1080). Using another resolutions may be problematic.
+- The tournament overlay size depends on the streamer or recorder's screen resolution.
+- Streamers or recorders of the tournament must adjust their `settings.ini` values depending on the resolution of tournament overlay as the default setting is based on FHD resolution (1920x1080).
 
 ## Winner Elements
 


### PR DESCRIPTION
I added a tab in the wiki called **Tournament** as per AiAe's request. It should be under the **Multiplayer** tab.

Everything should be there except for the skinnable images.