### PR TITLE
Ranking Criteria 2022 Overhaul

### DIFF
--- a/en-US/ranking/criteria.md
+++ b/en-US/ranking/criteria.md
@@ -2,78 +2,173 @@
 name: Ranking Criteria
 ---
 
-
 # Quaver Ranking Criteria
 
-In order to get a mapset ranked, it must follow the criteria listed below. In the event that it does not, you may be asked to modify your mapset and resubmit it again for rank.
+In order to get a mapset ranked, it must follow the ranking criteria listed below. In the event of it breaking the criteria you may be asked to modify your mapset.
 
-If you're looking for the process of getting a mapset ranked, see: [Quaver Ranking Process](/docs/Ranking/Process).
+The ranking criteria is divided into rules and guidelines.
+* Rules are, literally, rules that may not be broken under any circumstances.
+* Guidelines try to guide the mapper and may be ignored when deemed reasonable.
 
-## Mandatory
+If you're looking for the steps of getting a mapset ranked, see: [Quaver Ranking Process](/docs/Ranking/Process).
 
-**You must follow all the requirements listed in this section. Failing to meet all the requirements will not allow your map to receive ranked status.**
+# Metadata
 
-### Metadata
+#### Rules
 
-The following pertains to metadata that your maps contain such as song artists, titles, and tags.
+* **Metadata must be consistent across difficulties.** The only exception being specific map-descriptive tags, such as pattern names, that improve the searchability of singular difficulties.
 
-* **The artist and title must be absolutely correct.**
-* **The artist and title must be romanized.** However, non-romanized characters are allowed to be used in source and tags.
-* **The artist, title and source must not repeat in tags.** However, romanizing or translating the source in tags is encouraged, in case it's relevant.
-* **Tags must contain the genre of the song.**
-* **Every difficulty must have a difficulty name.**
+## Artist
 
-### Media
+#### Rules
 
-The following pertains to media files such as background images and audio files that are contained in your mapset.
+* **The artist must be absolutely correct.**
+* **The artist must be romanized.** Non-romanized artist can be added to tags.
+* **The artist must not repeat in tags.** Only exception being the case where the artist appears in a relevant tag, such as song genre.
+* If there is no existing person to credit as the artist, `Unknown Artist` must be used.
 
-* **The resolution of background images must be at least 1280x720** and of exceptionally high quality. The file size of a background image must not exceed 4 MB.
-* **The mapset must contain only one audio file.** Multiple song file mapsets are not eligible to be ranked.
+## Title
+
+#### Rules
+
+* **The title must be absolutely correct.**
+* **The title must be romanized.** Non-romanized title can be added to tags. Loan words from other languages should use the original words instead of attempted romanization.
+* **The title must not repeat in tags.** Only exception being the case where the song title appears in a relevant tag, such as song genre.
+
+## Source
+
+#### Rules
+
+* **The source field must be used if the song is directly from a video game, album, series etc.**
+* **Remixes, arrangements, covers etc. that are based on another song should use the original song's source.**
+* **Song compilations, medleys and other pieces of media with multiple songs without a common source should have the sources put in the tags.** This rule does not apply if the piece of media is linked to a source itself, such as an album.
+* **The source must be romanized** Non-romanized source can be added to tags.
+
+## Tags
+
+#### Rules
+
+* **The tags must contain the genre of the song.**
+* **The tags must be comma-separated.** This is to ensure that tags consisting of multiple words can be easily distinguished.
+
+#### Guidelines
+
+* Including relevant tags such as language, instruments or metadata translations is encouraged.
+
+## Standardization
+
+The following metadata rules are put in place to create consistency within the ranked section.
+
+* Any form of `vs.`, `VS`, etc. indicating collaboration between artists should be formatted as `vs.`.
+* Any form of `feat.`, `ft.`, etc. indicating a featured artist should be formatted as `feat.`.
+* If a fictional character is credited as the artist of a song, the artist should be formatted as `Character (CV: Voice Actor)`
+* If a song is used in a TV program, series, or similar media as an opening/ending song, `(TV Size)` marker must be used at the end of the title. If the title contains similar marker by default, it should be replaced with `(TV Size)`.
+* If a song title contains short version or game version markers by default, they must be replaced with `(Short Ver.)` and `(Game Ver.)` respectively.
+* Unofficial cut versions of songs must use `(Cut Ver.)` at the end of the title. If the title contains a length marker by default, it should be replaced with `(Cut Ver.)`. This rule does not apply to songs that are shortened in ways that nearly match their original verisons or songs that consist of a full loop from a looping track.
+* If a song has been edited to have higher tempo, `(Sped Up Ver.)` marker must be used at the end of the title. If the title contains similar marker by default, it should be replaced with `(Sped Up Ver.)`.
+* If a song has been edited to have lower tempo, `(Slowed Down Ver.)` marker must be used at the end of the title. If the title contains similar marker by default, it should be replaced with `(Slowed Down Ver.)`.
+* Special unicode characters must be filtered to their nearest standard equivalent. Stars such as `★ ☆` should be substituted with an asterisk (`*`). Other special characters should be romanized or left out on a case-by-case basis.
+
+# Media
+
+#### Rules
+
+* **The total file size of the mapset must not exceed 50 MB.**
+
+## Background
+
+#### Rules
+
+* **Every map in the mapset must have a background image.** Using different background images for different maps is acceptable.
+* **The resolution of a background image must be at least 1280x720.**
+* **The file size of a background image must not exceed 4 MB.**
+* **The background must be of exceptionally high quality.** 
+* **the background must be appropriate for players of all ages and should not contain explicit content.**
+
+#### Guidelines
+
+* The background should show relevance to the song in some way. While mappers are allowed creative freedom when it comes to choosing backgrounds, completely unrelated background images that do not compliment the song in any way should generally not be used.
+
+## Audio
+
+#### Rules
+
+* **The mapset must contain only one audio file.**  Mapsets with multiple audio files are not eligible to be ranked.
 * **MP3 is the only allowed audio file format.**
-* **The maximum bitrate allowed for audio files is 192kbps.**
-* **The total file size must not exceed 50 MB.**
+* **The maximum bitrate allowed for MP3 files is 192kbps.** 
+* **The audio must be appropriate for players of all ages and should not include content that is offensive just for the sake of being offensive.**
 
-### Maps
+# Maps
+
+#### Rules
 
 The following requirements are for the individual maps themselves.
 
 * **Autoplay must be able to achieve a 100% (X-Grade) score.**
 * **The maps must not have overlapping notes.**
-* **All long note releases must have at least 36 milliseconds of space after them.** The value is derived from 2x of the Standard "Marvelous" timing window.
 * **The maps cannot have more than 30 seconds of consecutive break time.**
 * **More than 75% of the length of the song must have notes to play.**
 * **At least one note must be placed in every column.**
 * **The maps must be at least 45 seconds long.**
-* **The maps must be timed as accurately as possible.** Timing points must not be used in place of scroll velocity changes.
-* **The maps must have a song select preview point that sufficently compliments the song.** It's usually placed before the chorus or at the beginning of a section. A solid preview point attracts more players to try the map.
+* **The maps must be timed as accurately as possible.** The waveform in the editor may be used for more accurate timing. 
+* **The maps must have a song select preview point that sufficently compliments the song.** Preview point is commonly placed at the beginning of a clear segment in the song, such as the chorus. A solid preview point attracts more players to try the map.
 
-### Difficulty Spread
+#### Guidelines
 
-The following pertains to the spread of difficulty each mapset must follow.
+* **Notes should correlate to sounds in the music.** This includes but is not limited to:
+     * Representing distinct sounds with certain amounts of notes
+     * Representing distinct sounds with certain patterns of notes
+* **Using layering is encouraged.** Mapping different instruments in the song will make the map reflect the music more.
+* **Paying attention to chord/pattern consistency is encouraged.** Mapping certain elements of the song with very different ideas in quick succession without justification lowers the map's quality.
+* **The intensity of the map should generally be synced with the music.** If a song is relatively mellow, the map should reflect this and vice versa.
+* Examples of cases where **simplifications to completely accurately following the music should be favoured** include but are not limited to:
+     * Causing an inappropriate difficulty spike relative to the rest of the map
+     * Song can be effectively represented with more consistent and predictable snap
+     * Pattern would be unreasonable to execute with perfect accuracy
+     * Intended difficulty of the map does not match the song intensity
+* **Maps with multiple BPM points should have a constant scrollspeed across them.** This can be achieved by either turning off the option "BPM Affects SV" from the editor or manually countering the scrollspeed effects created by varying BPM using SV points. This does not apply in the rare cases where the intention is to create scrollspeed effects using the songs tempo variance. 
+* **Scroll Velocity changes should reflect the music.** Try to avoid changing SV when the must doesn’t call for it. This will generally make your map more difficult to read and harder to enjoy.
 
-##### Difficulty Names & Description
+## Difficulty Spread
 
-The standard names for difficulties in a mapset are Beginner, Easy, Normal, Hard, Insane, and Expert.
-Should you choose not to use the standard names, the difficulty names in your set must show clear sign of progression in difficulty consistent with that of the mapset and should be easy to interpret.
+| Length        | Minimum Required Maps |
+| ------------- | :-------------------: |
+| **0:45-2:29** |           2           |
+| **2:30+**     |           1           |
 
-The following descriptions are what each difficulty should typically look like. Keep in mind that this isn't concrete, and there is room for subjectivity in individual cases. It is only to serve a general outlook on how each map should look and feel.
+#### Rules
+
+* The standard names for difficulties in a mapset are **Beginner, Easy, Normal, Hard, Insane, and Expert**. Should you choose not to use the standard names, the difficulty names in your set must show clear sign of progression in difficulty consistent with that of the mapset and should be easy to interpret. The highest difficulty of each game mode is always free to have a custom difficulty name.
+     * Standard difficulty name may be added to the end of custom difficulty name in brackets to improve the interpretation of difficulty.
+* You are **not** permitted to skip difficulties for **sets with a song length between 0:45-2:29.** For instance, if you are making a 1 minute set with an Insane, you can either create a Hard or an Expert difficulty. Having a Beginner and an Insane is not allowed. **This rule does not apply to sets with a song length of 2:30 or longer.**
+* **Each game mode is treated separately.** If you are creating a mapset for both 4 Keys and 7 Keys, you must have a difficulty spread for both game modes.
+* **If a mapset has two game modes, each difficulty must be prefaced with either `4K` or `7K`** (Example: `7K Insane`).
+* **If a mapset contains guest difficulties, the guest difficulties creators must be credited in their respective difficulty names** (Example: `Flamingo's Hard`). Mapset's host should not be credited in this fashion.
+* **The number of difficulties created by the host of a mapset must be equal or higher than the largest number of guest difficulties created by a single user.** If a mapper with guest difficulties has contributed to the set with more difficulties than the host, the host should be changed. The creators of guest difficulties should also be credited in the tags.
+
+#### Guidelines
+
+* **Avoid the use of non-alphanumeric unicode characters in difficulty names.**
+
+### Difficulty descriptions
+
+The following descriptions are what each difficulty should typically look like. Keep in mind that this isn't concrete, and there is room for subjectivity in individual cases. It is only to serve a general outlook on how each map should look and feel. The following descriptions are crafted for approximately 180 BPM 4k difficulties.
 
 * **Beginner**
      * For players who are being exposed to rhythm games for the first time.
      * Notes should typically be on every other beat in most cases and once every beat to portray emphasis in the music.
      * Jumps are suitable for this difficulty when emphasizing important sounds in the music.
-     * Scroll velocity changes must not be used at this difficulty level for any other purposes than scroll velocity normalization.
 
 * **Easy**
      * This difficulty can be thought of as an "upgraded Beginner."
      * Players at this level will be able to play at slightly higher speeds and execute more complicated patterns.
      * One beat streams and 1/2 bursts are generally comfortable to these players.
      * Jumps can be used more freely but sparingly, as players at this level may still have trouble with them.
-     * Scroll velocity changes must not be used at this difficulty level for any other purposes than scroll velocity normalization.
 
 * **Normal**
      * Maps at this level should typically start branching into patterns that don't undermap the song as heavily compared to easy and beginner.
      * 1/2 rhythms with more complicated note placements and jumps are suitable for this difficulty.
+     * Short bursts of 1/4 notes may be used for emphasis.
 
 * **Hard**
      * At this level, your creativity as a mapper is able to shine as there are far less restrictions than the previous difficulties.
@@ -83,36 +178,10 @@ The following descriptions are what each difficulty should typically look like. 
 * **Insane**
      * Players at this level will be able to handle a wide variety of patterns at lower densities including but not limited to:
           * Light Jacks
-          * Complex Long Note Usage
+          * More Complex Long Note Usage
           * Light Jumpstreams
      * Denser patterns are suitable for this level if they are straightforward, and not difficult to execute - such as jumptrills.
 
 * **Expert**
      * From this point on, there aren't any restrictions on how hard it should be. Feel free to be creative.
 
-##### Difficulty Spread Rules
-
-| Length        | Minimum Required Maps |
-| ------------- | :-------------------: |
-| **0:45-2:29** |           2           |
-| **2:30+**     |           1           |
-
-##### Skipping Difficulties
-
-You are **not** permitted to skip difficulties for **sets with a song length between 0:45-2:29.** For instance, if you are making a 1 minute set with an Insane, you can either create a Hard or an Expert difficulty. Having a Beginner and an Insane is not allowed. **This rule does not apply to sets with a song length of 2:30 or longer.**
-
-##### Multi-Game Mode Sets
-
-Furthermore, **each game mode is treated separately.** If you are creating a mapset for both 4 Keys and 7 Keys, you must have a difficulty spread for both game modes.
-
-**If you have two game modes, each difficulty must contain either "4K" or "7K"** (Example: "7K Insane").
-
-## Guidelines
-
-The following are guidelines to consider when creating your mapset and submitting it for ranked status. **These are not mandatory and should be taken with a grain of salt.** Our intentions with this are to allow mappers to be creative with the types of maps they produce. As such, these guidelines are merely a way to increase your chances of getting your mapset ranked - although exceptions can be made.
-
-* **The intensity of the map should generally be synced with the music.** If a song is relatively mellow, the map should reflect this and vice versa.
-* **Your map should generally make use of layering.** - Mapping to different instruments in the song will make your map reflect the music more.
-* **Breaks should only be used when absolutely necessary** - A song will generally not have any silent moments throughout it. Breaks should be used sparingly - especially long ones.
-* **Scroll Velocity changes should reflect the music** - Try to avoid changing SV when the must doesn't call for it. This will generally make your map more difficult to read and harder to enjoy.
-* **The patterns you use should be consistent and follow the music** - Try to avoid using bursts where they aren't appropriate, such as before a dense stream section. Furthermore, try to avoid technical or intense patterns in places that do not call for them.


### PR DESCRIPTION
This PR includes:

- RC Structure Change | Old structure had All mandatory rules and optional guidelines separated, with mapping related subcategory division under them. New structure divides the criteria to three main parts: Metadata, Media and Maps, each of which have their own subcategories and own rules/guidelines. This makes it easier to add/modify information in the future, as everything has a logical place.

- Rewordings and placement switches of certain rules, for example, the rules regarding SV usage in low difficulties was moved from guidelines to rules where it belongs.

- Additions of larger rule concepts and metadata standardizations, about which I hope to spark discussion. It's important for every mapper/RS to be on the same wavelength when it comes to discussing the future of ranked section. Topics to discuss include:

— Addition of metadata standardization rules.
— Tags separated by comma to easily distinguish multi-word tags from single-word tags.
— Should it be required that the offsets and values of timing points match across difficulties. This affects timing line art and the BPM displaying/sorting in game.
— What source should take priority. This comes down to what is the intention of the source field in the game. Is it to group similar themed songs together for easy search/sorting (in which case game/movie/other media source should take priority) or is it to pinpoint down the first appearance of the song in any distribution method (in which case chronologically first source, usually an album, should be used)
— Is it OK to allow inconsistent tags across difficulties when it benefits the searchability of single difficulties, for example, when describing patterns used.

