### PR TITLE
Background filter alignment, judgement suggest size

### DIFF
--- a/en-US/skins/clientinterface.md
+++ b/en-US/skins/clientinterface.md
@@ -403,15 +403,16 @@ The client interface includes general skin elements that are present in all game
 
 ![Background Filter](/docs/images/Results/background-filter.png?v=2)
 
-| Animatable | Alignment |    Optimal Size    |
-| :--------: | :-------: | :----------------: |
-|     No     |     -     | 1920x1080/1920x208 |
+| Animatable |  Alignment  |    Optimal Size    |
+| :--------: | :---------: | :----------------: |
+|     No     |  TopCenter  | 1920x1080/1920x208 |
 
 **Notes:**
 
 - Overlays the background depending on type with normal blend.
 - Drawn on top of `background.png` or map background depending on skin.ini value.
 - 1920x1080 is used for `Background` or `None` type, while 1920x208 is used for `Header` or default.
+- Aligned to the bottom of the MenuBorder line.
 
 ---
 

--- a/en-US/skins/gameplayinterface.md
+++ b/en-US/skins/gameplayinterface.md
@@ -545,9 +545,9 @@ Notes:
 
 ![Judgement (Marv)](/docs/images/Judgements/judge-marv.png?v=2)
 
-| Animatable | Alignment | Suggested Size |
-| :--------: | :-------: | :------------: |
-|    Yes     | MidCenter |       -        |
+| Animatable | Alignment |      Suggested Size        |
+| :--------: | :-------: | :------------------------: |
+|    Yes     | MidCenter |  357x357 maximum per frame |
 
 **Notes:**
 
@@ -563,9 +563,9 @@ Notes:
 
 ![Judgement (Perf)](/docs/images/Judgements/judge-perf.png?v=2)
 
-| Animatable | Alignment | Suggested Size |
-| :--------: | :-------: | :------------: |
-|    Yes     | MidCenter |       -        |
+| Animatable | Alignment |      Suggested Size        |
+| :--------: | :-------: | :------------------------: |
+|    Yes     | MidCenter |  357x357 maximum per frame |
 
 **Notes:**
 
@@ -581,9 +581,9 @@ Notes:
 
 ![Judgement (Great)](/docs/images/Judgements/judge-great.png?v=2)
 
-| Animatable | Alignment | Suggested Size |
-| :--------: | :-------: | :------------: |
-|    Yes     | MidCenter |       -        |
+| Animatable | Alignment |      Suggested Size        |
+| :--------: | :-------: | :------------------------: |
+|    Yes     | MidCenter |  357x357 maximum per frame |
 
 **Notes:**
 
@@ -599,9 +599,9 @@ Notes:
 
 ![Judgement (Good)](/docs/images/Judgements/judge-good.png?v=2)
 
-| Animatable | Alignment | Suggested Size |
-| :--------: | :-------: | :------------: |
-|    Yes     | MidCenter |       -        |
+| Animatable | Alignment |      Suggested Size        |
+| :--------: | :-------: | :------------------------: |
+|    Yes     | MidCenter |  357x357 maximum per frame |
 
 **Notes:**
 
@@ -617,9 +617,9 @@ Notes:
 
 ![Judgement (Okay)](/docs/images/Judgements/judge-okay.png?v=2)
 
-| Animatable | Alignment | Suggested Size |
-| :--------: | :-------: | :------------: |
-|    Yes     | MidCenter |       -        |
+| Animatable | Alignment |      Suggested Size        |
+| :--------: | :-------: | :------------------------: |
+|    Yes     | MidCenter |  357x357 maximum per frame |
 
 **Notes:**
 
@@ -635,9 +635,9 @@ Notes:
 
 ![Judgement (Miss)](/docs/images/Judgements/judge-miss.png?v=2)
 
-| Animatable | Alignment | Suggested Size |
-| :--------: | :-------: | :------------: |
-|    Yes     | MidCenter |       -        |
+| Animatable | Alignment |      Suggested Size        |
+| :--------: | :-------: | :------------------------: |
+|    Yes     | MidCenter |  357x357 maximum per frame |
 
 **Notes:**
 


### PR DESCRIPTION
Added background filter alignment and note on where it aligns, otherwise it can be misunderstood that it just fills the whole screen when `ResultsBackgroundType = Background` like background.png. Problematic if you do something that should line up with other elements.

Added judgement suggested size for parity with #158 given that it's the only element with a scale config entry with a maximum rendered size at 1080p.