### PR TITLE
Update Judgement Timing Windows table

### DIFF
--- a/en-US/gameplay/README.md
+++ b/en-US/gameplay/README.md
@@ -67,8 +67,8 @@ All ranked scores are converted to the "Standard*" judgement window.
 | Perfect   | ±57ms    | ±52ms   | ±47ms  | **±43ms**  | ±39ms  | ±35ms  | ±32ms   | ±20ms      |
 | Great     | ±101ms   | ±91ms   | ±83ms  | **±76ms**  | ±69ms  | ±62ms  | ±57ms   | ±35ms      |
 | Good      | ±141ms   | ±128ms  | ±116ms | **±106ms** | ±96ms  | ±87ms  | ±79ms   | ±49ms      |
-| Okay      | ±169ms   | ±153ms  | ±139ms | **±127ms** | ±115ms | ±104ms | ±95ms   | ±59ms      |
-| Miss      | ±218ms   | ±198ms  | ±180ms | **±164ms** | ±149ms | ±135ms | ±123ms  | ±76ms      |
+| Okay      | ±169ms   | ±153ms  | ±139ms | **±127ms** | ±127ms | ±127ms | ±127ms  | ±127ms     |
+| Miss      | ±218ms   | ±198ms  | ±180ms | **±164ms** | ±164ms | ±164ms | ±164ms  | ±164ms     |
 
 #### Performance Rating
 


### PR DESCRIPTION
Updated the `Judgement Timing Windows` table after timing windows were changed in https://github.com/Quaver/Quaver/commit/d4a46c48c392e47f096f3b9b196caf4a9733daa5.