### PR TITLE
Fix Footer Jukebox dimensions

### DIFF
--- a/en-US/skins/clientinterface.md
+++ b/en-US/skins/clientinterface.md
@@ -127,7 +127,7 @@ The client interface includes general skin elements that are present in all game
 
 | Animatable |  Alignment   | Optimal Size |
 | :--------: | :----------: | :----------: |
-|     No     | BottomCenter |    500x54    |
+|     No     | BottomCenter |    510x54    |
 
 **Notes:**
 


### PR DESCRIPTION
Footer Jukebox's component dimensions actually are 510x54, not 500x54