### PR TITLE
Max file size rule change from 50mb to 100mb

### DIFF
--- a/en-US/ranking/criteria.md
+++ b/en-US/ranking/criteria.md
@@ -116,7 +116,7 @@ The following metadata rules are put in place to create consistency within the r
 
 ## Rules
 
-- **The total file size of the mapset must not exceed 50 MB.**
+- **The total file size of the mapset must not exceed 100 MB.**
 - **A mapset cannot contain unused files.**
 
 ## Guidelines


### PR DESCRIPTION
Change the max file size for ranking a map from 50 to 100 due to donator perks allowing up to 100mb upload now