### PR TITLE
Add glossary to TOC.ini

### DIFF
--- a/TOC.ini
+++ b/TOC.ini
@@ -26,6 +26,7 @@
 -: README
 -: criteria
 -: process
+-: glossary
 
 [faq]
 -: README


### PR DESCRIPTION
should fix an invalid link in docs/ranking